### PR TITLE
Lowering minSDK from 8 to 5.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,6 +4,6 @@
       android:versionCode="1"
       android:versionName="1.0.0">
 
-    <uses-sdk android:minSdkVersion="8" android:targetSdkVersion="17"/>
+    <uses-sdk android:minSdkVersion="5" android:targetSdkVersion="17"/>
 
 </manifest>


### PR DESCRIPTION
Running lint shows no dependencies on minSDKVersion 8. Lowering the minSDK to 5 allows bundling this library with a greater number of applications.

Specifically the maintainers of the Fdroid client were hesitant to merge a pull req I wrote to bundle AndroidPinning because their client has a minSDK of 5 versus the AndroidPinning minSDK of 8.

Thanks! Big fan of the library <3
