### PR TITLE
SHA-256 support

### DIFF
--- a/src/org/thoughtcrime/ssl/pinning/PinningTrustManager.java
+++ b/src/org/thoughtcrime/ssl/pinning/PinningTrustManager.java
@@ -113,7 +113,7 @@ public class PinningTrustManager implements X509TrustManager {
 
   private boolean isValidPin(X509Certificate certificate) throws CertificateException {
     try {
-      final MessageDigest digest = MessageDigest.getInstance("SHA1");
+      final MessageDigest digest = MessageDigest.getInstance("SHA-256");
       final byte[] spki          = certificate.getPublicKey().getEncoded();
       final byte[] pin           = digest.digest(spki);
 

--- a/tools/pin-b64.py
+++ b/tools/pin-b64.py
@@ -36,7 +36,7 @@ def main(argv):
     spki        = x509.get_pubkey()
     encodedSpki = spki.as_der()
 
-    digest = hashlib.sha1()
+    digest = hashlib.sha256()
     digest.update(encodedSpki)
 
     print "Calculating PIN for certificate: " + x509.get_subject().as_text()

--- a/tools/pin.py
+++ b/tools/pin.py
@@ -36,7 +36,7 @@ def main(argv):
     spki        = x509.get_pubkey()
     encodedSpki = spki.as_der()
 
-    digest = hashlib.sha1()
+    digest = hashlib.sha256()
     digest.update(encodedSpki)
 
     print "Calculating PIN for certificate: " + x509.get_subject().as_text()


### PR DESCRIPTION
Seeing as SHA-1 is currently being deprecated by Google as well as most CAs due to collision weaknesses, I think it's wise to upgrade the pins to SHA-256, especially as this library is used by many security-conscious applications.
