### PR TITLE
We need import the base64 before use it.

### DIFF
--- a/tools/pin-b64.py
+++ b/tools/pin-b64.py
@@ -25,7 +25,7 @@ If you need this to be something other than GPL, send me an email.
 """
 
 from M2Crypto import X509
-import sys, binascii, hashlib
+import sys, binascii, hashlib, base64
 
 def main(argv):
     if len(argv) < 1:


### PR DESCRIPTION
Hello, first, thanks for this great project. So, in order to use the ping-b64.py tool we need to import the base64 first.
